### PR TITLE
feat(index): add more bindings and api methods

### DIFF
--- a/lib/src/git_types.dart
+++ b/lib/src/git_types.dart
@@ -1704,3 +1704,27 @@ class GitSubmoduleStatus {
   @override
   String toString() => 'GitSubmoduleStatus.$_name';
 }
+
+/// Capabilities of system that affect index actions.
+class GitIndexCapability {
+  const GitIndexCapability._(this._value, this._name);
+  final int _value;
+  final String _name;
+
+  static const ignoreCase = GitIndexCapability._(1, 'ignoreCase');
+  static const noFileMode = GitIndexCapability._(2, 'noFileMode');
+  static const noSymlinks = GitIndexCapability._(4, 'noSymlinks');
+  static const fromOwner = GitIndexCapability._(-1, 'fromOwner');
+
+  static const List<GitIndexCapability> values = [
+    ignoreCase,
+    noFileMode,
+    noSymlinks,
+    fromOwner,
+  ];
+
+  int get value => _value;
+
+  @override
+  String toString() => 'GitIndexCapability.$_name';
+}

--- a/test/git_types_test.dart
+++ b/test/git_types_test.dart
@@ -561,5 +561,20 @@ void main() {
         );
       });
     });
+
+    group('GitIndexCapability', () {
+      test('returns correct values', () {
+        const expected = [1, 2, 4, -1];
+        final actual = GitIndexCapability.values.map((e) => e.value).toList();
+        expect(actual, expected);
+      });
+
+      test('returns string representation of object', () {
+        expect(
+          GitIndexCapability.ignoreCase.toString(),
+          'GitIndexCapability.ignoreCase',
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
Add bindings and api methods for:
- git_index_add_from_buffer
- git_index_caps
- git_index_conflict_add
- git_index_conflict_cleanup
- git_index_entry_is_conflict
- git_index_entry_stage
- git_index_path
- git_index_remove_directory
- git_index_set_caps
- git_index_update_all