### PR TITLE
feat(reference): add more bindings and API methods

### DIFF
--- a/lib/src/bindings/reference.dart
+++ b/lib/src/bindings/reference.dart
@@ -157,6 +157,25 @@ bool hasLog({
   return result == 1 || false;
 }
 
+/// Ensure there is a reflog for a particular reference.
+///
+/// Make sure that successive updates to the reference will append to its log.
+///
+/// Throws a [LibGit2Error] if error occured.
+void ensureLog({
+  required Pointer<git_repository> repoPointer,
+  required String refName,
+}) {
+  final refNameC = refName.toNativeUtf8().cast<Int8>();
+  final error = libgit2.git_reference_ensure_log(repoPointer, refNameC);
+
+  calloc.free(refNameC);
+
+  if (error < 0) {
+    throw LibGit2Error(libgit2.git_error_last());
+  }
+}
+
 /// Check if a reference is a local branch.
 bool isBranch(Pointer<git_reference> ref) {
   return libgit2.git_reference_is_branch(ref) == 1 || false;
@@ -408,6 +427,13 @@ Pointer<git_object> peel({
   } else {
     return out.value;
   }
+}
+
+/// Create a copy of an existing reference.
+Pointer<git_reference> duplicate(Pointer<git_reference> source) {
+  final out = calloc<Pointer<git_reference>>();
+  libgit2.git_reference_dup(out, source);
+  return out.value;
 }
 
 /// Free the given reference.

--- a/lib/src/reference.dart
+++ b/lib/src/reference.dart
@@ -139,6 +139,11 @@ class Reference {
     refdb_bindings.free(refdb);
   }
 
+  /// Creates a copy of an existing reference.
+  ///
+  /// **IMPORTANT**: Should be freed to release allocated memory.
+  Reference duplicate() => Reference(bindings.duplicate(_refPointer));
+
   /// Type of the reference.
   ReferenceType get type {
     return bindings.referenceType(_refPointer) == 1
@@ -240,6 +245,17 @@ class Reference {
       repoPointer: bindings.owner(_refPointer),
       name: name,
     );
+  }
+
+  /// Ensures there is a reflog for a particular reference.
+  ///
+  /// Makes sure that successive updates to the reference will append to its
+  /// log.
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  void ensureLog() {
+    final owner = bindings.owner(_refPointer);
+    bindings.ensureLog(repoPointer: owner, refName: name);
   }
 
   /// [RefLog] object.

--- a/test/reference_test.dart
+++ b/test/reference_test.dart
@@ -128,6 +128,19 @@ void main() {
       ref.free();
     });
 
+    test('duplicates existing reference', () {
+      expect(repo.references.length, 6);
+
+      final ref = repo.lookupReference('refs/heads/master');
+      final duplicate = ref.duplicate();
+
+      expect(repo.references.length, 6);
+      expect(duplicate, equals(ref));
+
+      duplicate.free();
+      ref.free();
+    });
+
     group('create direct', () {
       test('successfully creates with Oid as target', () {
         final ref = repo.lookupReference('refs/heads/master');


### PR DESCRIPTION
Add bindings and API methods for:
  - git_reference_dup
  - git_reference_ensure_log