### PR TITLE
feat(reflog): add more bindings and API methods

### DIFF
--- a/lib/src/bindings/reflog.dart
+++ b/lib/src/bindings/reflog.dart
@@ -2,6 +2,7 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:libgit2dart/src/bindings/libgit2_bindings.dart';
+import 'package:libgit2dart/src/error.dart';
 import 'package:libgit2dart/src/util.dart';
 
 /// Read the reflog for the given reference.
@@ -23,6 +24,90 @@ Pointer<git_reflog> read({
   return out.value;
 }
 
+/// Write an existing in-memory reflog object back to disk using an atomic file
+/// lock.
+void write(Pointer<git_reflog> reflog) {
+  final error = libgit2.git_reflog_write(reflog);
+
+  if (error < 0) {
+    throw LibGit2Error(libgit2.git_error_last());
+  }
+}
+
+/// Delete the reflog for the given reference.
+void delete({
+  required Pointer<git_repository> repoPointer,
+  required String name,
+}) {
+  final nameC = name.toNativeUtf8().cast<Int8>();
+  libgit2.git_reflog_delete(repoPointer, nameC);
+  calloc.free(nameC);
+}
+
+/// Rename a reflog.
+///
+/// The reflog to be renamed is expected to already exist.
+///
+/// The new name will be checked for validity.
+///
+/// Throws a [LibGit2Error] if error occured.
+void rename({
+  required Pointer<git_repository> repoPointer,
+  required String oldName,
+  required String newName,
+}) {
+  final oldNameC = oldName.toNativeUtf8().cast<Int8>();
+  final newNameC = newName.toNativeUtf8().cast<Int8>();
+  final error = libgit2.git_reflog_rename(repoPointer, oldNameC, newNameC);
+
+  calloc.free(oldNameC);
+  calloc.free(newNameC);
+
+  if (error < 0) {
+    throw LibGit2Error(libgit2.git_error_last());
+  }
+}
+
+/// Add a new entry to the in-memory reflog.
+///
+/// Throws a [LibGit2Error] if error occured.
+void add({
+  required Pointer<git_reflog> reflogPointer,
+  required Pointer<git_oid> oidPointer,
+  required Pointer<git_signature> committerPointer,
+  required String message,
+}) {
+  final messageC =
+      message.isEmpty ? nullptr : message.toNativeUtf8().cast<Int8>();
+
+  final error = libgit2.git_reflog_append(
+    reflogPointer,
+    oidPointer,
+    committerPointer,
+    messageC,
+  );
+
+  calloc.free(messageC);
+
+  if (error < 0) {
+    throw LibGit2Error(libgit2.git_error_last());
+  }
+}
+
+/// Remove an entry from the reflog by its index.
+///
+/// Throws a [LibGit2Error] if error occured.
+void remove({
+  required Pointer<git_reflog> reflogPointer,
+  required int index,
+}) {
+  final error = libgit2.git_reflog_drop(reflogPointer, index, 1);
+
+  if (error < 0) {
+    throw LibGit2Error(libgit2.git_error_last());
+  }
+}
+
 /// Get the number of log entries in a reflog.
 int entryCount(Pointer<git_reflog> reflog) =>
     libgit2.git_reflog_entrycount(reflog);
@@ -40,12 +125,23 @@ Pointer<git_reflog_entry> getByIndex({
 
 /// Get the log message.
 String entryMessage(Pointer<git_reflog_entry> entry) {
-  return libgit2.git_reflog_entry_message(entry).cast<Utf8>().toDartString();
+  final result = libgit2.git_reflog_entry_message(entry);
+  return result == nullptr ? '' : result.cast<Utf8>().toDartString();
 }
 
 /// Get the committer of this entry.
 Pointer<git_signature> entryCommiter(Pointer<git_reflog_entry> entry) {
   return libgit2.git_reflog_entry_committer(entry);
+}
+
+/// Get the new oid.
+Pointer<git_oid> entryOidNew(Pointer<git_reflog_entry> entry) {
+  return libgit2.git_reflog_entry_id_new(entry);
+}
+
+/// Get the old oid.
+Pointer<git_oid> entryOidOld(Pointer<git_reflog_entry> entry) {
+  return libgit2.git_reflog_entry_id_old(entry);
 }
 
 /// Free the reflog.

--- a/lib/src/reference.dart
+++ b/lib/src/reference.dart
@@ -139,6 +139,19 @@ class Reference {
     refdb_bindings.free(refdb);
   }
 
+  /// Ensures there is a reflog for a particular reference.
+  ///
+  /// Makes sure that successive updates to the reference will append to its
+  /// log.
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  static void ensureLog({
+    required Repository repo,
+    required String refName,
+  }) {
+    bindings.ensureLog(repoPointer: repo.pointer, refName: refName);
+  }
+
   /// Creates a copy of an existing reference.
   ///
   /// **IMPORTANT**: Should be freed to release allocated memory.
@@ -245,17 +258,6 @@ class Reference {
       repoPointer: bindings.owner(_refPointer),
       name: name,
     );
-  }
-
-  /// Ensures there is a reflog for a particular reference.
-  ///
-  /// Makes sure that successive updates to the reference will append to its
-  /// log.
-  ///
-  /// Throws a [LibGit2Error] if error occured.
-  void ensureLog() {
-    final owner = bindings.owner(_refPointer);
-    bindings.ensureLog(repoPointer: owner, refName: name);
   }
 
   /// [RefLog] object.

--- a/lib/src/reflog.dart
+++ b/lib/src/reflog.dart
@@ -18,6 +18,30 @@ class RefLog with IterableMixin<RefLogEntry> {
   /// Pointer to memory address for allocated reflog object.
   late final Pointer<git_reflog> _reflogPointer;
 
+  /// Deletes the reflog for the given reference.
+  static void delete(Reference ref) {
+    bindings.delete(repoPointer: ref.owner.pointer, name: ref.name);
+  }
+
+  /// Renames a reflog.
+  ///
+  /// The reflog to be renamed is expected to already exist.
+  ///
+  /// The new name will be checked for validity.
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  static void rename({
+    required Repository repo,
+    required String oldName,
+    required String newName,
+  }) {
+    bindings.rename(
+      repoPointer: repo.pointer,
+      oldName: oldName,
+      newName: newName,
+    );
+  }
+
   /// Lookups an entry by its index.
   ///
   /// Requesting the reflog entry with an index of 0 will return the most
@@ -30,6 +54,39 @@ class RefLog with IterableMixin<RefLogEntry> {
       ),
     );
   }
+
+  /// Adds a new entry to the in-memory reflog.
+  ///
+  /// [oid] is the OID the reference is now pointing to.
+  ///
+  /// [committer] is the signature of the committer.
+  ///
+  /// [message] is optional reflog message.
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  void add({
+    required Oid oid,
+    required Signature committer,
+    String message = '',
+  }) {
+    bindings.add(
+      reflogPointer: _reflogPointer,
+      oidPointer: oid.pointer,
+      committerPointer: committer.pointer,
+      message: message,
+    );
+  }
+
+  /// Removes an entry from the reflog by its [index].
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  void remove(int index) {
+    bindings.remove(reflogPointer: _reflogPointer, index: index);
+  }
+
+  /// Writes an existing in-memory reflog object back to disk using an atomic
+  /// file lock.
+  void write() => bindings.write(_reflogPointer);
 
   /// Releases memory allocated for reflog object.
   void free() => bindings.free(_reflogPointer);
@@ -47,10 +104,18 @@ class RefLogEntry {
   final Pointer<git_reflog_entry> _entryPointer;
 
   /// Log message.
+  ///
+  /// Returns empty string if there is no message.
   String get message => bindings.entryMessage(_entryPointer);
 
   /// Committer of this entry.
   Signature get committer => Signature(bindings.entryCommiter(_entryPointer));
+
+  /// New oid of entry at this time.
+  Oid get newOid => Oid(bindings.entryOidNew(_entryPointer));
+
+  /// Old oid of entry.
+  Oid get oldOid => Oid(bindings.entryOidOld(_entryPointer));
 
   @override
   String toString() => 'RefLogEntry{message: $message, committer: $committer}';

--- a/test/reference_test.dart
+++ b/test/reference_test.dart
@@ -128,6 +128,31 @@ void main() {
       ref.free();
     });
 
+    test('ensures updates to the reference will append to its log', () {
+      Reference.ensureLog(repo: repo, refName: 'refs/tags/tag');
+
+      final ref = repo.createReference(
+        name: 'refs/tags/tag',
+        target: repo[lastCommit],
+      );
+      final reflog = ref.log;
+
+      expect(reflog.length, 1);
+
+      reflog.free();
+      ref.free();
+    });
+
+    test('throws when trying to ensure there is a reflog and error occurs', () {
+      expect(
+        () => Reference.ensureLog(
+          repo: Repository(nullptr),
+          refName: 'refs/tags/tag',
+        ),
+        throwsA(isA<LibGit2Error>()),
+      );
+    });
+
     test('duplicates existing reference', () {
       expect(repo.references.length, 6);
 


### PR DESCRIPTION
Add bindings and API methods for:
  - git_reflog_delete
  - git_reflog_append
  - git_reflog_drop
  - git_reflog_entry_id_new
  - git_reflog_entry_id_old
  - git_reflog_rename
  - git_reflog_write