### PR TITLE
feat(checkout)!: add ability to checkout commit

### DIFF
--- a/test/blob_test.dart
+++ b/test/blob_test.dart
@@ -128,7 +128,7 @@ void main() {
     });
 
     test('filters content of a blob with provided commit for attributes', () {
-      repo.checkout(refName: 'refs/tags/v0.2');
+      repo.checkout(target: 'refs/tags/v0.2');
 
       final blobOid = repo.createBlob('clrf\nclrf\n');
       final blob = repo.lookupBlob(blobOid);

--- a/test/diff_test.dart
+++ b/test/diff_test.dart
@@ -337,7 +337,7 @@ index e69de29..c217c63 100644
         );
 
         final diff2 = Diff.parse(patchText);
-        repo.checkout(refName: 'HEAD', strategy: {GitCheckout.force});
+        repo.checkout(target: 'HEAD', strategy: {GitCheckout.force});
         expect(
           repo.applies(diff: diff2, location: GitApplyLocation.both),
           true,
@@ -357,7 +357,7 @@ index e69de29..c217c63 100644
 
         final diff2 = Diff.parse(patchText);
         final hunk = diff2.patches.first.hunks.first;
-        repo.checkout(refName: 'HEAD', strategy: {GitCheckout.force});
+        repo.checkout(target: 'HEAD', strategy: {GitCheckout.force});
         expect(
           repo.applies(
             diff: diff2,
@@ -375,7 +375,7 @@ index e69de29..c217c63 100644
         final diff = Diff.parse(patchText);
         final file = File(p.join(tmpDir.path, 'subdir', 'modified_file'));
 
-        repo.checkout(refName: 'HEAD', strategy: {GitCheckout.force});
+        repo.checkout(target: 'HEAD', strategy: {GitCheckout.force});
         expect(file.readAsStringSync(), '');
 
         repo.apply(diff: diff);
@@ -405,7 +405,7 @@ index e69de29..c217c63 100644
         final hunk = diff.patches.first.hunks.first;
         final file = File(p.join(tmpDir.path, 'subdir', 'modified_file'));
 
-        repo.checkout(refName: 'HEAD', strategy: {GitCheckout.force});
+        repo.checkout(target: 'HEAD', strategy: {GitCheckout.force});
         expect(file.readAsStringSync(), '');
 
         repo.apply(diff: diff, hunkIndex: hunk.index);
@@ -417,7 +417,7 @@ index e69de29..c217c63 100644
       test('applies diff to tree', () {
         final diff = Diff.parse(patchText);
 
-        repo.checkout(refName: 'HEAD', strategy: {GitCheckout.force});
+        repo.checkout(target: 'HEAD', strategy: {GitCheckout.force});
         final head = repo.head;
         final commit = repo.lookupCommit(head.target);
         final tree = commit.tree;
@@ -444,7 +444,7 @@ index e69de29..c217c63 100644
         final diff = Diff.parse(patchText);
         final hunk = diff.patches.first.hunks.first;
 
-        repo.checkout(refName: 'HEAD', strategy: {GitCheckout.force});
+        repo.checkout(target: 'HEAD', strategy: {GitCheckout.force});
         final head = repo.head;
         final commit = repo.lookupCommit(head.target);
         final tree = commit.tree;

--- a/test/index_test.dart
+++ b/test/index_test.dart
@@ -365,7 +365,7 @@ void main() {
         oid: conflictBranch.target,
       );
 
-      conflictRepo.checkout(refName: 'refs/heads/feature');
+      conflictRepo.checkout(target: 'refs/heads/feature');
 
       conflictRepo.merge(commit: commit);
 
@@ -421,7 +421,7 @@ void main() {
         oid: conflictBranch.target,
       );
 
-      conflictRepo.checkout(refName: 'refs/heads/our-conflict');
+      conflictRepo.checkout(target: 'refs/heads/our-conflict');
 
       conflictRepo.merge(commit: commit);
 
@@ -449,7 +449,7 @@ void main() {
         oid: conflictBranch.target,
       );
 
-      conflictRepo.checkout(refName: 'refs/heads/feature');
+      conflictRepo.checkout(target: 'refs/heads/feature');
 
       conflictRepo.merge(commit: commit);
 

--- a/test/merge_test.dart
+++ b/test/merge_test.dart
@@ -159,7 +159,7 @@ Another feature edit
           repo: repo,
           oid: conflictBranch.target,
         );
-        repo.checkout(refName: 'refs/heads/feature');
+        repo.checkout(target: 'refs/heads/feature');
         final index = repo.index;
 
         repo.merge(commit: commit);

--- a/test/rebase_test.dart
+++ b/test/rebase_test.dart
@@ -43,7 +43,7 @@ void main() {
         reference: feature,
       );
 
-      repo.checkout(refName: feature.name);
+      repo.checkout(target: feature.name);
       expect(() => repo.index['.gitignore'], throwsA(isA<ArgumentError>()));
 
       final rebase = Rebase.init(
@@ -141,7 +141,7 @@ void main() {
       final feature = repo.lookupReference('refs/heads/feature');
       final upstream = AnnotatedCommit.lookup(repo: repo, oid: repo[shas[1]]);
 
-      repo.checkout(refName: feature.name);
+      repo.checkout(target: feature.name);
       expect(() => repo.index['conflict_file'], throwsA(isA<ArgumentError>()));
 
       final rebase = Rebase.init(
@@ -194,7 +194,7 @@ void main() {
       final conflict = repo.lookupReference('refs/heads/conflict-branch');
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: conflict.target);
 
-      repo.checkout(refName: conflict.name);
+      repo.checkout(target: conflict.name);
 
       final rebase = Rebase.init(
         repo: repo,
@@ -231,7 +231,7 @@ void main() {
       final conflict = repo.lookupReference('refs/heads/conflict-branch');
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: conflict.target);
 
-      repo.checkout(refName: conflict.name);
+      repo.checkout(target: conflict.name);
 
       final rebase = Rebase.init(
         repo: repo,
@@ -257,7 +257,7 @@ void main() {
       final conflict = repo.lookupReference('refs/heads/conflict-branch');
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: conflict.target);
 
-      repo.checkout(refName: conflict.name);
+      repo.checkout(target: conflict.name);
 
       final rebase = Rebase.init(
         repo: repo,


### PR DESCRIPTION
BREAKING CHANGE: rename `checkout()` method argument `refName` to `target` and add ability to accept commit Oid