### PR TITLE
refactor!: use class names instead of aliases from Repository in tests

### DIFF
--- a/lib/src/bindings/diff.dart
+++ b/lib/src/bindings/diff.dart
@@ -66,7 +66,7 @@ Pointer<git_diff> indexToWorkdir({
 /// Create a diff between a tree and repository index.
 Pointer<git_diff> treeToIndex({
   required Pointer<git_repository> repoPointer,
-  required Pointer<git_tree> treePointer,
+  required Pointer<git_tree>? treePointer,
   required Pointer<git_index> indexPointer,
   required int flags,
   required int contextLines,
@@ -82,7 +82,7 @@ Pointer<git_diff> treeToIndex({
   libgit2.git_diff_tree_to_index(
     out,
     repoPointer,
-    treePointer,
+    treePointer ?? nullptr,
     indexPointer,
     opts,
   );
@@ -97,7 +97,7 @@ Pointer<git_diff> treeToIndex({
 /// Throws a [LibGit2Error] if error occured.
 Pointer<git_diff> treeToWorkdir({
   required Pointer<git_repository> repoPointer,
-  required Pointer<git_tree> treePointer,
+  required Pointer<git_tree>? treePointer,
   required int flags,
   required int contextLines,
   required int interhunkLines,
@@ -112,7 +112,7 @@ Pointer<git_diff> treeToWorkdir({
   final error = libgit2.git_diff_tree_to_workdir(
     out,
     repoPointer,
-    treePointer,
+    treePointer ?? nullptr,
     opts,
   );
 
@@ -170,8 +170,8 @@ Pointer<git_diff> treeToWorkdirWithIndex({
 /// Throws a [LibGit2Error] if error occured.
 Pointer<git_diff> treeToTree({
   required Pointer<git_repository> repoPointer,
-  required Pointer<git_tree> oldTreePointer,
-  required Pointer<git_tree> newTreePointer,
+  required Pointer<git_tree>? oldTreePointer,
+  required Pointer<git_tree>? newTreePointer,
   required int flags,
   required int contextLines,
   required int interhunkLines,
@@ -186,8 +186,8 @@ Pointer<git_diff> treeToTree({
   final error = libgit2.git_diff_tree_to_tree(
     out,
     repoPointer,
-    oldTreePointer,
-    newTreePointer,
+    oldTreePointer ?? nullptr,
+    newTreePointer ?? nullptr,
     opts,
   );
 

--- a/lib/src/branch.dart
+++ b/lib/src/branch.dart
@@ -41,7 +41,8 @@ class Branch {
     );
   }
 
-  /// Lookups a branch by its [name] and [type] in a [repo]sitory.
+  /// Lookups a branch by its [name] and [type] in a [repo]sitory. Lookups in
+  /// local branches by default.
   ///
   /// The branch name will be checked for validity.
   ///

--- a/lib/src/commit.dart
+++ b/lib/src/commit.dart
@@ -178,6 +178,38 @@ class Commit {
     );
   }
 
+  /// Reverts commit, producing changes in the index and working directory.
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  void revert() {
+    bindings.revert(
+      repoPointer: bindings.owner(_commitPointer),
+      commitPointer: _commitPointer,
+    );
+  }
+
+  /// Reverts commit against provided [commit], producing an index that
+  /// reflects the result of the revert.
+  ///
+  /// [mainline] is parent of the commit if it is a merge (i.e. 1, 2).
+  ///
+  /// **IMPORTANT**: produced index should be freed to release allocated memory.
+  ///
+  /// Throws a [LibGit2Error] if error occured.
+  Index revertTo({
+    required Commit commit,
+    int mainline = 0,
+  }) {
+    return Index(
+      bindings.revertCommit(
+        repoPointer: bindings.owner(_commitPointer),
+        revertCommitPointer: _commitPointer,
+        ourCommitPointer: commit.pointer,
+        mainline: mainline,
+      ),
+    );
+  }
+
   /// Wncoding for the message of a commit, as a string representing a standard
   /// encoding name.
   String get messageEncoding => bindings.messageEncoding(_commitPointer);

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -3,7 +3,6 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:libgit2dart/libgit2dart.dart';
-import 'package:libgit2dart/src/bindings/diff.dart' as diff_bindings;
 import 'package:libgit2dart/src/bindings/index.dart' as bindings;
 import 'package:libgit2dart/src/bindings/libgit2_bindings.dart';
 
@@ -299,91 +298,6 @@ class Index with IterableMixin<IndexEntry> {
   /// Throws a [LibGit2Error] if error occured.
   void removeAll(List<String> path) =>
       bindings.removeAll(indexPointer: _indexPointer, pathspec: path);
-
-  /// Creates a diff with the difference between two index objects.
-  ///
-  /// [index] is the [Index] object to diff to.
-  ///
-  /// [flags] is a combination of [GitDiff] flags. Defaults to [GitDiff.normal].
-  ///
-  /// [contextLines] is the number of unchanged lines that define the boundary
-  /// of a hunk (and to display before and after). Defaults to 3.
-  ///
-  /// [interhunkLines] is the maximum number of unchanged lines between hunk
-  /// boundaries before the hunks will be merged into one. Defaults to 0.
-  ///
-  /// Throws a [LibGit2Error] if error occured.
-  Diff diffToIndex({
-    required Index index,
-    Set<GitDiff> flags = const {GitDiff.normal},
-    int contextLines = 3,
-    int interhunkLines = 0,
-  }) {
-    return Diff(
-      diff_bindings.indexToIndex(
-        repoPointer: bindings.owner(_indexPointer),
-        oldIndexPointer: _indexPointer,
-        newIndexPointer: index.pointer,
-        flags: flags.fold(0, (acc, e) => acc | e.value),
-        contextLines: contextLines,
-        interhunkLines: interhunkLines,
-      ),
-    );
-  }
-
-  /// Creates a diff between the repository index and the workdir directory.
-  ///
-  /// [flags] is a combination of [GitDiff] flags. Defaults to [GitDiff.normal].
-  ///
-  /// [contextLines] is the number of unchanged lines that define the boundary
-  /// of a hunk (and to display before and after). Defaults to 3.
-  ///
-  /// [interhunkLines] is the maximum number of unchanged lines between hunk
-  /// boundaries before the hunks will be merged into one. Defaults to 0.
-  Diff diffToWorkdir({
-    Set<GitDiff> flags = const {GitDiff.normal},
-    int contextLines = 3,
-    int interhunkLines = 0,
-  }) {
-    return Diff(
-      diff_bindings.indexToWorkdir(
-        repoPointer: bindings.owner(_indexPointer),
-        indexPointer: _indexPointer,
-        flags: flags.fold(0, (acc, e) => acc | e.value),
-        contextLines: contextLines,
-        interhunkLines: interhunkLines,
-      ),
-    );
-  }
-
-  /// Creates a diff between a tree and repository index.
-  ///
-  /// [tree] is the [Tree] object to diff from.
-  ///
-  /// [flags] is a combination of [GitDiff] flags. Defaults to [GitDiff.normal].
-  ///
-  /// [contextLines] is the number of unchanged lines that define the boundary
-  /// of a hunk (and to display before and after). Defaults to 3.
-  ///
-  /// [interhunkLines] is the maximum number of unchanged lines between hunk
-  /// boundaries before the hunks will be merged into one. Defaults to 0.
-  Diff diffToTree({
-    required Tree tree,
-    Set<GitDiff> flags = const {GitDiff.normal},
-    int contextLines = 3,
-    int interhunkLines = 0,
-  }) {
-    return Diff(
-      diff_bindings.treeToIndex(
-        repoPointer: bindings.owner(_indexPointer),
-        treePointer: tree.pointer,
-        indexPointer: _indexPointer,
-        flags: flags.fold(0, (acc, e) => acc | e.value),
-        contextLines: contextLines,
-        interhunkLines: interhunkLines,
-      ),
-    );
-  }
 
   /// Releases memory allocated for index object.
   void free() => bindings.free(_indexPointer);

--- a/lib/src/revparse.dart
+++ b/lib/src/revparse.dart
@@ -14,8 +14,7 @@ class RevParse {
   /// point to an intermediate reference. When such expressions are being
   /// passed in, reference_out will be valued as well.
   ///
-  /// **IMPORTANT**: The returned object and reference should be freed to
-  /// release allocated memory.
+  /// **IMPORTANT**: Should be freed to release allocated memory.
   ///
   /// Throws a [LibGit2Error] if error occured.
   RevParse.ext({required Repository repo, required String spec}) {
@@ -41,7 +40,7 @@ class RevParse {
   /// See `man gitrevisions`, or https://git-scm.com/docs/git-rev-parse.html#_specifying_revisions
   /// for information on the syntax accepted.
   ///
-  /// The returned object should be released when no longer needed.
+  /// **IMPORTANT**: Should be freed to release allocated memory.
   ///
   /// Throws a [LibGit2Error] if error occured.
   static Commit single({required Repository repo, required String spec}) {

--- a/lib/src/submodule.dart
+++ b/lib/src/submodule.dart
@@ -65,12 +65,12 @@ class Submodule {
   /// Throws a [LibGit2Error] if error occured.
   static void init({
     required Repository repo,
-    required String submodule,
+    required String name,
     bool overwrite = false,
   }) {
     final submodulePointer = bindings.lookup(
       repoPointer: repo.pointer,
-      name: submodule,
+      name: name,
     );
 
     bindings.init(submodulePointer: submodulePointer, overwrite: overwrite);
@@ -91,13 +91,13 @@ class Submodule {
   /// Throws a [LibGit2Error] if error occured.
   static void update({
     required Repository repo,
-    required String submodule,
+    required String name,
     bool init = false,
     Callbacks callbacks = const Callbacks(),
   }) {
     final submodulePointer = bindings.lookup(
       repoPointer: repo.pointer,
-      name: submodule,
+      name: name,
     );
 
     bindings.update(

--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -1,7 +1,6 @@
 import 'dart:ffi';
 
 import 'package:libgit2dart/libgit2dart.dart';
-import 'package:libgit2dart/src/bindings/diff.dart' as diff_bindings;
 import 'package:libgit2dart/src/bindings/libgit2_bindings.dart';
 import 'package:libgit2dart/src/bindings/tree.dart' as bindings;
 
@@ -89,93 +88,6 @@ class Tree {
 
   /// Number of entries listed in a tree.
   int get length => bindings.entryCount(_treePointer);
-
-  /// Creates a diff between a tree and the working directory.
-  ///
-  /// [flags] is a combination of [GitDiff] flags. Defaults to [GitDiff.normal].
-  ///
-  /// [contextLines] is the number of unchanged lines that define the boundary
-  /// of a hunk (and to display before and after). Defaults to 3.
-  ///
-  /// [interhunkLines] is the maximum number of unchanged lines between hunk
-  /// boundaries before the hunks will be merged into one. Defaults to 0.
-  ///
-  /// Throws a [LibGit2Error] if error occured.
-  Diff diffToWorkdir({
-    Set<GitDiff> flags = const {GitDiff.normal},
-    int contextLines = 3,
-    int interhunkLines = 0,
-  }) {
-    return Diff(
-      diff_bindings.treeToWorkdir(
-        repoPointer: bindings.owner(_treePointer),
-        treePointer: _treePointer,
-        flags: flags.fold(0, (acc, e) => acc | e.value),
-        contextLines: contextLines,
-        interhunkLines: interhunkLines,
-      ),
-    );
-  }
-
-  /// Creates a diff between a tree and repository index.
-  ///
-  /// [index] is the [Index] object to diff to.
-  ///
-  /// [flags] is a combination of [GitDiff] flags. Defaults to [GitDiff.normal].
-  ///
-  /// [contextLines] is the number of unchanged lines that define the boundary
-  /// of a hunk (and to display before and after). Defaults to 3.
-  ///
-  /// [interhunkLines] is the maximum number of unchanged lines between hunk
-  /// boundaries before the hunks will be merged into one. Defaults to 0.
-  Diff diffToIndex({
-    required Index index,
-    Set<GitDiff> flags = const {GitDiff.normal},
-    int contextLines = 3,
-    int interhunkLines = 0,
-  }) {
-    return Diff(
-      diff_bindings.treeToIndex(
-        repoPointer: bindings.owner(_treePointer),
-        treePointer: _treePointer,
-        indexPointer: index.pointer,
-        flags: flags.fold(0, (acc, e) => acc | e.value),
-        contextLines: contextLines,
-        interhunkLines: interhunkLines,
-      ),
-    );
-  }
-
-  /// Creates a diff with the difference between two tree objects.
-  ///
-  /// [tree] is the [Tree] object to diff to.
-  ///
-  /// [flags] is a combination of [GitDiff] flags. Defaults to [GitDiff.normal].
-  ///
-  /// [contextLines] is the number of unchanged lines that define the boundary
-  /// of a hunk (and to display before and after). Defaults to 3.
-  ///
-  /// [interhunkLines] is the maximum number of unchanged lines between hunk
-  /// boundaries before the hunks will be merged into one. Defaults to 0.
-  ///
-  /// Throws a [LibGit2Error] if error occured.
-  Diff diffToTree({
-    required Tree tree,
-    Set<GitDiff> flags = const {GitDiff.normal},
-    int contextLines = 3,
-    int interhunkLines = 0,
-  }) {
-    return Diff(
-      diff_bindings.treeToTree(
-        repoPointer: bindings.owner(_treePointer),
-        oldTreePointer: _treePointer,
-        newTreePointer: tree.pointer,
-        flags: flags.fold(0, (acc, e) => acc | e.value),
-        contextLines: contextLines,
-        interhunkLines: interhunkLines,
-      ),
-    );
-  }
 
   /// Releases memory allocated for tree object.
   void free() => bindings.free(_treePointer);

--- a/test/blame_test.dart
+++ b/test/blame_test.dart
@@ -60,7 +60,8 @@ void main() {
 
   group('Blame', () {
     test('returns the blame for provided file', () {
-      final blame = repo.blame(
+      final blame = Blame.file(
+        repo: repo,
         path: 'feature_file',
         oldestCommit: repo['f17d0d4'],
       );
@@ -86,11 +87,14 @@ void main() {
     });
 
     test('throws when provided file path is invalid', () {
-      expect(() => repo.blame(path: 'invalid'), throwsA(isA<LibGit2Error>()));
+      expect(
+        () => Blame.file(repo: repo, path: 'invalid'),
+        throwsA(isA<LibGit2Error>()),
+      );
     });
 
     test('returns blame for buffer', () {
-      final blame = repo.blame(path: 'feature_file');
+      final blame = Blame.file(repo: repo, path: 'feature_file');
       expect(blame.length, 2);
 
       final bufferBlame = Blame.buffer(reference: blame, buffer: ' ');
@@ -106,7 +110,7 @@ void main() {
     });
 
     test('throws when trying to get blame for empty buffer', () {
-      final blame = repo.blame(path: 'feature_file');
+      final blame = Blame.file(repo: repo, path: 'feature_file');
       expect(
         () => Blame.buffer(reference: blame, buffer: ''),
         throwsA(isA<LibGit2Error>()),
@@ -115,7 +119,8 @@ void main() {
     });
 
     test('returns the blame for provided file with minMatchCharacters set', () {
-      final blame = repo.blame(
+      final blame = Blame.file(
+        repo: repo,
         path: 'feature_file',
         minMatchCharacters: 1,
         flags: {GitBlameFlag.trackCopiesSameFile},
@@ -127,7 +132,7 @@ void main() {
     });
 
     test('returns the blame for provided line', () {
-      final blame = repo.blame(path: 'feature_file');
+      final blame = Blame.file(repo: repo, path: 'feature_file');
 
       final hunk = blame.forLine(1);
 
@@ -148,21 +153,22 @@ void main() {
     });
 
     test('throws when provided index for hunk is invalid', () {
-      final blame = repo.blame(path: 'feature_file');
+      final blame = Blame.file(repo: repo, path: 'feature_file');
       expect(() => blame[10], throwsA(isA<RangeError>()));
 
       blame.free();
     });
 
     test('throws when provided line number for hunk is invalid', () {
-      final blame = repo.blame(path: 'feature_file');
+      final blame = Blame.file(repo: repo, path: 'feature_file');
       expect(() => blame.forLine(10), throwsA(isA<RangeError>()));
 
       blame.free();
     });
 
     test('returns the blame for provided file with newestCommit argument', () {
-      final blame = repo.blame(
+      final blame = Blame.file(
+        repo: repo,
         path: 'feature_file',
         newestCommit: repo['fc38877'],
         flags: {GitBlameFlag.ignoreWhitespace},
@@ -190,7 +196,8 @@ void main() {
 
     test('returns the blame for provided file with minLine and maxLine set',
         () {
-      final blame = repo.blame(
+      final blame = Blame.file(
+        repo: repo,
         path: 'feature_file',
         minLine: 1,
         maxLine: 1,
@@ -217,7 +224,7 @@ void main() {
     });
 
     test('returns string representation of BlameHunk object', () {
-      final blame = repo.blame(path: 'feature_file');
+      final blame = Blame.file(repo: repo, path: 'feature_file');
       expect(blame.toString(), contains('BlameHunk{'));
       blame.free();
     });

--- a/test/note_test.dart
+++ b/test/note_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   group('Note', () {
     test('returns list of notes', () {
-      final notes = repo.notes;
+      final notes = Note.list(repo);
 
       expect(notes.length, 2);
 
@@ -49,12 +49,12 @@ void main() {
 
     test('throws when trying to get list of notes and error occurs', () {
       Directory(p.join(repo.path, 'refs', 'notes')).deleteSync(recursive: true);
-      expect(() => repo.notes, throwsA(isA<LibGit2Error>()));
+      expect(() => Note.list(repo), throwsA(isA<LibGit2Error>()));
     });
 
     test('lookups note', () {
       final head = repo.head;
-      final note = repo.lookupNote(annotatedOid: head.target);
+      final note = Note.lookup(repo: repo, annotatedOid: head.target);
 
       expect(note.oid.sha, notesExpected[1]['oid']);
       expect(note.message, notesExpected[1]['message']);
@@ -71,14 +71,15 @@ void main() {
         time: 1234,
       );
       final head = repo.head;
-      final noteOid = repo.createNote(
+      final noteOid = Note.create(
+        repo: repo,
         author: signature,
         committer: signature,
         annotatedOid: head.target,
         note: 'New note for HEAD',
         force: true,
       );
-      final noteBlob = repo.lookupBlob(noteOid);
+      final noteBlob = Blob.lookup(repo: repo, oid: noteOid);
 
       expect(noteOid.sha, 'ffd6e2ceaf91c00ea6d29e2e897f906da720529f');
       expect(noteBlob.content, 'New note for HEAD');
@@ -90,7 +91,8 @@ void main() {
 
     test('throws when trying to create note and error occurs', () {
       expect(
-        () => Repository(nullptr).createNote(
+        () => Note.create(
+          repo: Repository(nullptr),
           author: Signature(nullptr),
           committer: Signature(nullptr),
           annotatedOid: repo['0' * 40],
@@ -108,14 +110,15 @@ void main() {
       );
       final head = repo.head;
 
-      repo.deleteNote(
+      Note.delete(
+        repo: repo,
         annotatedOid: repo.head.target,
         author: signature,
         committer: signature,
       );
 
       expect(
-        () => repo.lookupNote(annotatedOid: head.target),
+        () => Note.lookup(repo: repo, annotatedOid: head.target),
         throwsA(isA<LibGit2Error>()),
       );
 
@@ -125,7 +128,8 @@ void main() {
 
     test('throws when trying to delete note and error occurs', () {
       expect(
-        () => Repository(nullptr).deleteNote(
+        () => Note.delete(
+          repo: Repository(nullptr),
           author: Signature(nullptr),
           committer: Signature(nullptr),
           annotatedOid: repo['0' * 40],
@@ -135,7 +139,7 @@ void main() {
     });
 
     test('returns string representation of Note object', () {
-      final note = repo.lookupNote(annotatedOid: repo['821ed6e']);
+      final note = Note.lookup(repo: repo, annotatedOid: repo['821ed6e']);
       expect(note.toString(), contains('Note{'));
       note.free();
     });

--- a/test/packbuilder_test.dart
+++ b/test/packbuilder_test.dart
@@ -188,10 +188,14 @@ void main() {
 
     test('packs with provided packDelegate', () {
       Directory(packDirPath).createSync();
+
       void packDelegate(PackBuilder packBuilder) {
         final branches = repo.branchesLocal;
         for (final branch in branches) {
-          final ref = repo.lookupReference('refs/heads/${branch.name}');
+          final ref = Reference.lookup(
+            repo: repo,
+            name: 'refs/heads/${branch.name}',
+          );
           for (final commit in repo.log(oid: ref.target)) {
             packBuilder.addRecursively(commit.oid);
             commit.free();

--- a/test/patch_test.dart
+++ b/test/patch_test.dart
@@ -96,8 +96,8 @@ index e69de29..0000000
     });
 
     test('creates from blobs', () {
-      final a = repo.lookupBlob(oldBlobOid);
-      final b = repo.lookupBlob(newBlobOid);
+      final a = Blob.lookup(repo: repo, oid: oldBlobOid);
+      final b = Blob.lookup(repo: repo, oid: newBlobOid);
       final patch = Patch.create(
         a: a,
         b: b,
@@ -111,7 +111,7 @@ index e69de29..0000000
     });
 
     test('creates from one blob (add)', () {
-      final b = repo.lookupBlob(newBlobOid);
+      final b = Blob.lookup(repo: repo, oid: newBlobOid);
       final patch = Patch.create(
         a: null,
         b: b,
@@ -125,7 +125,7 @@ index e69de29..0000000
     });
 
     test('creates from one blob (delete)', () {
-      final a = repo.lookupBlob(oldBlobOid);
+      final a = Blob.lookup(repo: repo, oid: oldBlobOid);
       final patch = Patch.create(
         a: a,
         b: null,
@@ -139,7 +139,7 @@ index e69de29..0000000
     });
 
     test('creates from blob and buffer', () {
-      final a = repo.lookupBlob(oldBlobOid);
+      final a = Blob.lookup(repo: repo, oid: oldBlobOid);
       final patch = Patch.create(
         a: a,
         b: newBlob,
@@ -153,9 +153,8 @@ index e69de29..0000000
     });
 
     test('throws when argument is not Blob or String', () {
-      final commit = repo.lookupCommit(
-        repo['fc38877b2552ab554752d9a77e1f48f738cca79b'],
-      );
+      final commit = Commit.lookup(repo: repo, oid: repo['fc38877']);
+
       expect(
         () => Patch.create(
           a: commit,

--- a/test/rebase_test.dart
+++ b/test/rebase_test.dart
@@ -32,12 +32,12 @@ void main() {
         email: 'author@email.com',
         time: 1234,
       );
-      final master = repo.lookupReference('refs/heads/master');
+      final master = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final branchHead = AnnotatedCommit.fromReference(
         repo: repo,
         reference: master,
       );
-      final feature = repo.lookupReference('refs/heads/feature');
+      final feature = Reference.lookup(repo: repo, name: 'refs/heads/feature');
       final ontoHead = AnnotatedCommit.fromReference(
         repo: repo,
         reference: feature,
@@ -90,7 +90,7 @@ void main() {
         email: 'author@email.com',
         time: 1234,
       );
-      final feature = repo.lookupReference('refs/heads/feature');
+      final feature = Reference.lookup(repo: repo, name: 'refs/heads/feature');
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: feature.target);
 
       final rebase = Rebase.init(
@@ -136,9 +136,9 @@ void main() {
         email: 'author@email.com',
         time: 1234,
       );
-      final master = repo.lookupReference('refs/heads/master');
+      final master = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final branchHead = AnnotatedCommit.lookup(repo: repo, oid: master.target);
-      final feature = repo.lookupReference('refs/heads/feature');
+      final feature = Reference.lookup(repo: repo, name: 'refs/heads/feature');
       final upstream = AnnotatedCommit.lookup(repo: repo, oid: repo[shas[1]]);
 
       repo.checkout(target: feature.name);
@@ -189,9 +189,12 @@ void main() {
         email: 'author@email.com',
         time: 1234,
       );
-      final master = repo.lookupReference('refs/heads/master');
+      final master = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final branchHead = AnnotatedCommit.lookup(repo: repo, oid: master.target);
-      final conflict = repo.lookupReference('refs/heads/conflict-branch');
+      final conflict = Reference.lookup(
+        repo: repo,
+        name: 'refs/heads/conflict-branch',
+      );
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: conflict.target);
 
       repo.checkout(target: conflict.name);
@@ -226,9 +229,12 @@ void main() {
         email: 'author@email.com',
         time: 1234,
       );
-      final master = repo.lookupReference('refs/heads/master');
+      final master = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final branchHead = AnnotatedCommit.lookup(repo: repo, oid: master.target);
-      final conflict = repo.lookupReference('refs/heads/conflict-branch');
+      final conflict = Reference.lookup(
+        repo: repo,
+        name: 'refs/heads/conflict-branch',
+      );
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: conflict.target);
 
       repo.checkout(target: conflict.name);
@@ -252,9 +258,12 @@ void main() {
     });
 
     test('aborts rebase in progress', () {
-      final master = repo.lookupReference('refs/heads/master');
+      final master = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final branchHead = AnnotatedCommit.lookup(repo: repo, oid: master.target);
-      final conflict = repo.lookupReference('refs/heads/conflict-branch');
+      final conflict = Reference.lookup(
+        repo: repo,
+        name: 'refs/heads/conflict-branch',
+      );
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: conflict.target);
 
       repo.checkout(target: conflict.name);
@@ -282,7 +291,7 @@ void main() {
     });
 
     test('opens an existing rebase', () {
-      final feature = repo.lookupReference('refs/heads/feature');
+      final feature = Reference.lookup(repo: repo, name: 'refs/heads/feature');
       final ontoHead = AnnotatedCommit.lookup(repo: repo, oid: feature.target);
 
       final rebase = Rebase.init(

--- a/test/reference_test.dart
+++ b/test/reference_test.dart
@@ -26,7 +26,7 @@ void main() {
   group('Reference', () {
     test('returns a list', () {
       expect(
-        repo.references,
+        Reference.list(repo),
         [
           'refs/heads/feature',
           'refs/heads/master',
@@ -40,7 +40,7 @@ void main() {
 
     test('throws when trying to get a list of references and error occurs', () {
       expect(
-        () => Repository(nullptr).references,
+        () => Reference.list(Repository(nullptr)),
         throwsA(isA<LibGit2Error>()),
       );
     });
@@ -50,7 +50,7 @@ void main() {
       expect(head.type, ReferenceType.direct);
       head.free();
 
-      final ref = repo.lookupReference('HEAD');
+      final ref = Reference.lookup(repo: repo, name: 'HEAD');
       expect(ref.type, ReferenceType.symbolic);
       ref.free();
     });
@@ -62,7 +62,7 @@ void main() {
     });
 
     test('returns SHA hex of symbolic reference', () {
-      final ref = repo.lookupReference('HEAD');
+      final ref = Reference.lookup(repo: repo, name: 'HEAD');
       expect(ref.target.sha, lastCommit);
       ref.free();
     });
@@ -81,7 +81,8 @@ void main() {
     });
 
     test('returns the short name', () {
-      final ref = repo.createReference(
+      final ref = Reference.create(
+        repo: repo,
         name: 'refs/remotes/origin/upstream',
         target: repo[lastCommit],
       );
@@ -96,34 +97,37 @@ void main() {
     });
 
     test('checks if reference is a local branch', () {
-      final ref = repo.lookupReference('refs/heads/feature');
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/feature');
       expect(ref.isBranch, true);
       ref.free();
     });
 
     test('checks if reference is a note', () {
-      final ref = repo.lookupReference('refs/heads/master');
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
       expect(ref.isNote, false);
       ref.free();
     });
 
     test('checks if reference is a remote branch', () {
-      final ref = repo.lookupReference('refs/remotes/origin/master');
+      final ref = Reference.lookup(
+        repo: repo,
+        name: 'refs/remotes/origin/master',
+      );
       expect(ref.isRemote, true);
       ref.free();
     });
 
     test('checks if reference is a tag', () {
-      final ref = repo.lookupReference('refs/tags/v0.1');
+      final ref = Reference.lookup(repo: repo, name: 'refs/tags/v0.1');
       expect(ref.isTag, true);
       ref.free();
     });
 
     test('checks if reflog exists for the reference', () {
-      var ref = repo.lookupReference('refs/heads/master');
+      var ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
       expect(ref.hasLog, true);
 
-      ref = repo.lookupReference('refs/tags/v0.1');
+      ref = Reference.lookup(repo: repo, name: 'refs/tags/v0.1');
       expect(ref.hasLog, false);
 
       ref.free();
@@ -132,7 +136,8 @@ void main() {
     test('ensures updates to the reference will append to its log', () {
       Reference.ensureLog(repo: repo, refName: 'refs/tags/tag');
 
-      final ref = repo.createReference(
+      final ref = Reference.create(
+        repo: repo,
         name: 'refs/tags/tag',
         target: repo[lastCommit],
       );
@@ -157,7 +162,7 @@ void main() {
     test('duplicates existing reference', () {
       expect(repo.references.length, 6);
 
-      final ref = repo.lookupReference('refs/heads/master');
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final duplicate = ref.duplicate();
 
       expect(repo.references.length, 6);
@@ -169,8 +174,9 @@ void main() {
 
     group('create direct', () {
       test('creates with oid as target', () {
-        final ref = repo.lookupReference('refs/heads/master');
-        final refFromOid = repo.createReference(
+        final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
+        final refFromOid = Reference.create(
+          repo: repo,
           name: 'refs/tags/from.oid',
           target: ref.target,
         );
@@ -183,7 +189,8 @@ void main() {
 
       test('creates with log message', () {
         repo.setIdentity(name: 'name', email: 'email');
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'refs/heads/log.message',
           target: repo[lastCommit],
           logMessage: 'log message',
@@ -202,7 +209,8 @@ void main() {
 
       test('throws if target is not valid', () {
         expect(
-          () => repo.createReference(
+          () => Reference.create(
+            repo: repo,
             name: 'refs/tags/invalid',
             target: '78b',
           ),
@@ -210,7 +218,8 @@ void main() {
         );
 
         expect(
-          () => repo.createReference(
+          () => Reference.create(
+            repo: repo,
             name: 'refs/tags/invalid',
             target: 0,
           ),
@@ -220,7 +229,8 @@ void main() {
 
       test('throws if name is not valid', () {
         expect(
-          () => repo.createReference(
+          () => Reference.create(
+            repo: repo,
             name: 'refs/tags/invalid~',
             target: repo[lastCommit],
           ),
@@ -229,12 +239,14 @@ void main() {
       });
 
       test('creates with force flag if name already exists', () {
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'refs/tags/test',
           target: repo[lastCommit],
         );
 
-        final forceRef = repo.createReference(
+        final forceRef = Reference.create(
+          repo: repo,
           name: 'refs/tags/test',
           target: repo[lastCommit],
           force: true,
@@ -247,13 +259,15 @@ void main() {
       });
 
       test('throws if name already exists', () {
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'refs/tags/test',
           target: repo[lastCommit],
         );
 
         expect(
-          () => repo.createReference(
+          () => Reference.create(
+            repo: repo,
             name: 'refs/tags/test',
             target: repo[lastCommit],
           ),
@@ -266,7 +280,8 @@ void main() {
 
     group('create symbolic', () {
       test('creates with valid target', () {
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'refs/tags/symbolic',
           target: 'refs/heads/master',
         );
@@ -278,12 +293,14 @@ void main() {
       });
 
       test('creates with force flag if name already exists', () {
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'refs/tags/test',
           target: 'refs/heads/master',
         );
 
-        final forceRef = repo.createReference(
+        final forceRef = Reference.create(
+          repo: repo,
           name: 'refs/tags/test',
           target: 'refs/heads/master',
           force: true,
@@ -297,13 +314,15 @@ void main() {
       });
 
       test('throws if name already exists', () {
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'refs/tags/exists',
           target: 'refs/heads/master',
         );
 
         expect(
-          () => repo.createReference(
+          () => Reference.create(
+            repo: repo,
             name: 'refs/tags/exists',
             target: 'refs/heads/master',
           ),
@@ -315,7 +334,8 @@ void main() {
 
       test('throws if name is not valid', () {
         expect(
-          () => repo.createReference(
+          () => Reference.create(
+            repo: repo,
             name: 'refs/tags/invalid~',
             target: 'refs/heads/master',
           ),
@@ -325,7 +345,8 @@ void main() {
 
       test('creates with log message', () {
         repo.setIdentity(name: 'name', email: 'email');
-        final ref = repo.createReference(
+        final ref = Reference.create(
+          repo: repo,
           name: 'HEAD',
           target: 'refs/heads/feature',
           force: true,
@@ -347,27 +368,27 @@ void main() {
     test('deletes reference', () {
       expect(repo.references, contains('refs/tags/v0.1'));
 
-      repo.deleteReference('refs/tags/v0.1');
+      Reference.delete(repo: repo, name: 'refs/tags/v0.1');
       expect(repo.references, isNot(contains('refs/tags/v0.1')));
     });
 
     group('finds', () {
       test('with provided name', () {
-        final ref = repo.lookupReference('refs/heads/master');
+        final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
         expect(ref.target.sha, lastCommit);
         ref.free();
       });
 
       test('throws when error occured', () {
         expect(
-          () => repo.lookupReference('refs/heads/not/there'),
+          () => Reference.lookup(repo: repo, name: 'refs/heads/not/there'),
           throwsA(isA<LibGit2Error>()),
         );
       });
     });
 
     test('returns log for reference', () {
-      final ref = repo.lookupReference('refs/heads/master');
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final reflog = ref.log;
       expect(reflog.last.message, 'commit (initial): init');
 
@@ -377,7 +398,7 @@ void main() {
 
     group('set target', () {
       test('sets direct reference with provided oid target', () {
-        final ref = repo.lookupReference('refs/heads/master');
+        final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
         ref.setTarget(target: repo[newCommit]);
         expect(ref.target.sha, newCommit);
 
@@ -385,7 +406,7 @@ void main() {
       });
 
       test('sets symbolic target with provided reference name', () {
-        final ref = repo.lookupReference('HEAD');
+        final ref = Reference.lookup(repo: repo, name: 'HEAD');
         expect(ref.target.sha, lastCommit);
 
         ref.setTarget(target: 'refs/heads/feature');
@@ -395,7 +416,7 @@ void main() {
       });
 
       test('sets target with log message', () {
-        final ref = repo.lookupReference('HEAD');
+        final ref = Reference.lookup(repo: repo, name: 'HEAD');
         expect(ref.target.sha, lastCommit);
 
         repo.setIdentity(name: 'name', email: 'email');
@@ -411,7 +432,7 @@ void main() {
       });
 
       test('throws on invalid target', () {
-        final ref = repo.lookupReference('HEAD');
+        final ref = Reference.lookup(repo: repo, name: 'HEAD');
         expect(
           () => ref.setTarget(target: 'refs/heads/invalid~'),
           throwsA(isA<LibGit2Error>()),
@@ -430,7 +451,8 @@ void main() {
 
     group('rename', () {
       test('renames reference', () {
-        repo.renameReference(
+        Reference.rename(
+          repo: repo,
           oldName: 'refs/tags/v0.1',
           newName: 'refs/tags/renamed',
         );
@@ -441,7 +463,8 @@ void main() {
 
       test('throws on invalid name', () {
         expect(
-          () => repo.renameReference(
+          () => Reference.rename(
+            repo: repo,
             oldName: 'refs/tags/v0.1',
             newName: 'refs/tags/invalid~',
           ),
@@ -451,7 +474,8 @@ void main() {
 
       test('throws if name already exists', () {
         expect(
-          () => repo.renameReference(
+          () => Reference.rename(
+            repo: repo,
             oldName: 'refs/tags/v0.1',
             newName: 'refs/tags/v0.2',
           ),
@@ -460,20 +484,24 @@ void main() {
       });
 
       test('renames with force flag set to true', () {
-        final ref1 = repo.lookupReference('refs/tags/v0.1');
-        final ref2 = repo.lookupReference('refs/tags/v0.2');
+        final ref1 = Reference.lookup(repo: repo, name: 'refs/tags/v0.1');
+        final ref2 = Reference.lookup(repo: repo, name: 'refs/tags/v0.2');
 
         expect(ref1.target.sha, '78b8bf123e3952c970ae5c1ce0a3ea1d1336f6e8');
         expect(ref2.target.sha, 'f0fdbf506397e9f58c59b88dfdd72778ec06cc0c');
         expect(repo.references.length, 6);
 
-        repo.renameReference(
+        Reference.rename(
+          repo: repo,
           oldName: 'refs/tags/v0.1',
           newName: 'refs/tags/v0.2',
           force: true,
         );
 
-        final updatedRef1 = repo.lookupReference('refs/tags/v0.2');
+        final updatedRef1 = Reference.lookup(
+          repo: repo,
+          name: 'refs/tags/v0.2',
+        );
         expect(
           updatedRef1.target.sha,
           '78b8bf123e3952c970ae5c1ce0a3ea1d1336f6e8',
@@ -487,9 +515,9 @@ void main() {
     });
 
     test('checks equality', () {
-      final ref1 = repo.lookupReference('refs/heads/master');
-      final ref2 = repo.lookupReference('refs/heads/master');
-      final ref3 = repo.lookupReference('refs/heads/feature');
+      final ref1 = Reference.lookup(repo: repo, name: 'refs/heads/master');
+      final ref2 = Reference.lookup(repo: repo, name: 'refs/heads/master');
+      final ref3 = Reference.lookup(repo: repo, name: 'refs/heads/feature');
 
       expect(ref1 == ref2, true);
       expect(ref1 != ref2, false);
@@ -502,8 +530,8 @@ void main() {
     });
 
     test('peels to non-tag object when no type is provided', () {
-      final ref = repo.lookupReference('refs/heads/master');
-      final commit = repo.lookupCommit(ref.target);
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
+      final commit = Commit.lookup(repo: repo, oid: ref.target);
       final peeled = ref.peel() as Commit;
 
       expect(peeled.oid, commit.oid);
@@ -514,14 +542,15 @@ void main() {
     });
 
     test('peels to object of provided type', () {
-      final ref = repo.lookupReference('refs/heads/master');
-      final blob = repo.lookupBlob(repo['9c78c21']);
-      final blobRef = repo.createReference(
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
+      final blob = Blob.lookup(repo: repo, oid: repo['9c78c21']);
+      final blobRef = Reference.create(
+        repo: repo,
         name: 'refs/tags/blob',
         target: blob.oid,
       );
-      final tagRef = repo.lookupReference('refs/tags/v0.2');
-      final commit = repo.lookupCommit(ref.target);
+      final tagRef = Reference.lookup(repo: repo, name: 'refs/tags/v0.2');
+      final commit = Commit.lookup(repo: repo, oid: ref.target);
       final tree = commit.tree;
 
       final peeledCommit = ref.peel(GitObject.commit) as Commit;
@@ -570,7 +599,7 @@ void main() {
     });
 
     test('returns string representation of Reference object', () {
-      final ref = repo.lookupReference('refs/heads/master');
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
       expect(ref.toString(), contains('Reference{'));
       ref.free();
     });

--- a/test/reset_test.dart
+++ b/test/reset_test.dart
@@ -42,7 +42,7 @@ void main() {
       expect(contents, 'Feature edit\n');
 
       final index = repo.index;
-      final diff = index.diffToWorkdir();
+      final diff = Diff.indexToWorkdir(repo: repo, index: index);
       expect(diff.deltas, isEmpty);
 
       index.free();
@@ -57,7 +57,7 @@ void main() {
       expect(contents, 'Feature edit\n');
 
       final index = repo.index;
-      final diff = index.diffToWorkdir();
+      final diff = Diff.indexToWorkdir(repo: repo, index: index);
       expect(diff.deltas.length, 1);
 
       index.free();

--- a/test/stash_test.dart
+++ b/test/stash_test.dart
@@ -33,13 +33,13 @@ void main() {
     test('saves changes to stash', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
       expect(repo.status.isEmpty, true);
     });
 
     test('throws when trying to save and error occurs', () {
       expect(
-        () => Repository(nullptr).createStash(stasher: stasher),
+        () => Stash.create(repo: Repository(nullptr), stasher: stasher),
         throwsA(isA<LibGit2Error>()),
       );
     });
@@ -48,7 +48,8 @@ void main() {
       final swpPath = File(p.join(repo.workdir, 'some.swp'));
       swpPath.writeAsStringSync('ignored');
 
-      repo.createStash(
+      Stash.create(
+        repo: repo,
         stasher: stasher,
         flags: {GitStash.includeUntracked, GitStash.includeIgnored},
       );
@@ -64,7 +65,7 @@ void main() {
       final index = repo.index;
       index.add('file');
 
-      repo.createStash(stasher: stasher, flags: {GitStash.keepIndex});
+      Stash.create(repo: repo, stasher: stasher, flags: {GitStash.keepIndex});
       expect(repo.status.isEmpty, false);
       expect(repo.stashes.length, 1);
 
@@ -74,20 +75,20 @@ void main() {
     test('applies changes from stash', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
       expect(repo.status.isEmpty, true);
 
-      repo.applyStash();
+      Stash.apply(repo: repo);
       expect(repo.status, contains('file'));
     });
 
     test('applies changes from stash with paths provided', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
       expect(repo.status.isEmpty, true);
 
-      repo.applyStash(paths: ['file']);
+      Stash.apply(repo: repo, paths: ['file']);
       expect(repo.status, contains('file'));
     });
 
@@ -97,11 +98,15 @@ void main() {
       index.add('stash.this');
       expect(index.find('stash.this'), true);
 
-      repo.createStash(stasher: stasher, flags: {GitStash.includeUntracked});
+      Stash.create(
+        repo: repo,
+        stasher: stasher,
+        flags: {GitStash.includeUntracked},
+      );
       expect(repo.status.isEmpty, true);
       expect(index.find('stash.this'), false);
 
-      repo.applyStash(reinstateIndex: true);
+      Stash.apply(repo: repo, reinstateIndex: true);
       expect(repo.status, contains('stash.this'));
       expect(index.find('stash.this'), true);
 
@@ -111,17 +116,20 @@ void main() {
     test('throws when trying to apply with wrong index', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
 
-      expect(() => repo.applyStash(index: 10), throwsA(isA<LibGit2Error>()));
+      expect(
+        () => Stash.apply(repo: repo, index: 10),
+        throwsA(isA<LibGit2Error>()),
+      );
     });
 
     test('drops stash', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
       final stash = repo.stashes.first;
-      repo.dropStash(index: stash.index);
+      Stash.drop(repo: repo, index: stash.index);
 
       expect(() => repo.applyStash(), throwsA(isA<LibGit2Error>()));
     });
@@ -129,29 +137,32 @@ void main() {
     test('throws when trying to drop with wrong index', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
 
-      expect(() => repo.dropStash(index: 10), throwsA(isA<LibGit2Error>()));
+      expect(
+        () => Stash.drop(repo: repo, index: 10),
+        throwsA(isA<LibGit2Error>()),
+      );
     });
 
     test('pops from stash', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
-      repo.popStash();
+      Stash.create(repo: repo, stasher: stasher);
+      Stash.pop(repo: repo);
 
       expect(repo.status, contains('file'));
-      expect(() => repo.applyStash(), throwsA(isA<LibGit2Error>()));
+      expect(() => Stash.apply(repo: repo), throwsA(isA<LibGit2Error>()));
     });
 
     test('pops from stash with provided path', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
-      repo.popStash(paths: ['file']);
+      Stash.create(repo: repo, stasher: stasher);
+      Stash.pop(repo: repo, paths: ['file']);
 
       expect(repo.status, contains('file'));
-      expect(() => repo.applyStash(), throwsA(isA<LibGit2Error>()));
+      expect(() => Stash.apply(repo: repo), throwsA(isA<LibGit2Error>()));
     });
 
     test('pops from stash including index changes', () {
@@ -160,11 +171,15 @@ void main() {
       index.add('stash.this');
       expect(index.find('stash.this'), true);
 
-      repo.createStash(stasher: stasher, flags: {GitStash.includeUntracked});
+      Stash.create(
+        repo: repo,
+        stasher: stasher,
+        flags: {GitStash.includeUntracked},
+      );
       expect(repo.status.isEmpty, true);
       expect(index.find('stash.this'), false);
 
-      repo.popStash(reinstateIndex: true);
+      Stash.pop(repo: repo, reinstateIndex: true);
       expect(repo.status, contains('stash.this'));
       expect(index.find('stash.this'), true);
 
@@ -174,17 +189,20 @@ void main() {
     test('throws when trying to pop with wrong index', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher);
+      Stash.create(repo: repo, stasher: stasher);
 
-      expect(() => repo.popStash(index: 10), throwsA(isA<LibGit2Error>()));
+      expect(
+        () => Stash.pop(repo: repo, index: 10),
+        throwsA(isA<LibGit2Error>()),
+      );
     });
 
     test('returns list of stashes', () {
       File(filePath).writeAsStringSync('edit', mode: FileMode.append);
 
-      repo.createStash(stasher: stasher, message: 'WIP');
+      Stash.create(repo: repo, stasher: stasher, message: 'WIP');
 
-      final stash = repo.stashes.first;
+      final stash = Stash.list(repo).first;
 
       expect(repo.stashes.length, 1);
       expect(stash.index, 0);
@@ -194,7 +212,11 @@ void main() {
     test('returns string representation of Stash object', () {
       File(p.join(repo.workdir, 'stash.this')).writeAsStringSync('stash');
 
-      repo.createStash(stasher: stasher, flags: {GitStash.includeUntracked});
+      Stash.create(
+        repo: repo,
+        stasher: stasher,
+        flags: {GitStash.includeUntracked},
+      );
 
       expect(repo.stashes[0].toString(), contains('Stash{'));
     });

--- a/test/tag_test.dart
+++ b/test/tag_test.dart
@@ -17,7 +17,7 @@ void main() {
     tmpDir = setupRepo(Directory(p.join('test', 'assets', 'test_repo')));
     repo = Repository.open(tmpDir.path);
     tagOid = repo['f0fdbf506397e9f58c59b88dfdd72778ec06cc0c'];
-    tag = repo.lookupTag(tagOid);
+    tag = Tag.lookup(repo: repo, oid: tagOid);
   });
 
   tearDown(() {
@@ -33,7 +33,7 @@ void main() {
 
     test('throws when trying to lookup tag for invalid oid', () {
       expect(
-        () => repo.lookupTag(repo['0' * 40]),
+        () => Tag.lookup(repo: repo, oid: repo['0' * 40]),
         throwsA(isA<LibGit2Error>()),
       );
     });
@@ -84,7 +84,7 @@ void main() {
         message: message,
       );
 
-      final newTag = repo.lookupTag(oid);
+      final newTag = Tag.lookup(repo: repo, oid: oid);
       final tagger = newTag.tagger;
       final newTagTarget = newTag.target as Commit;
 
@@ -111,7 +111,7 @@ void main() {
         targetType: GitObject.commit,
       );
 
-      final newTag = repo.lookupReference('refs/tags/$tagName');
+      final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
 
       expect(newTag.shorthand, tagName);
       expect(newTag.target, target);
@@ -138,7 +138,7 @@ void main() {
         message: message,
       );
 
-      final newTag = repo.lookupTag(oid);
+      final newTag = Tag.lookup(repo: repo, oid: oid);
       final tagger = newTag.tagger;
       final newTagTarget = newTag.target as Tree;
 
@@ -164,7 +164,7 @@ void main() {
         targetType: GitObject.tree,
       );
 
-      final newTag = repo.lookupReference('refs/tags/$tagName');
+      final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
 
       expect(newTag.shorthand, tagName);
       expect(newTag.target, target);
@@ -191,7 +191,7 @@ void main() {
         message: message,
       );
 
-      final newTag = repo.lookupTag(oid);
+      final newTag = Tag.lookup(repo: repo, oid: oid);
       final tagger = newTag.tagger;
       final newTagTarget = newTag.target as Blob;
 
@@ -217,7 +217,7 @@ void main() {
         targetType: GitObject.blob,
       );
 
-      final newTag = repo.lookupReference('refs/tags/$tagName');
+      final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
 
       expect(newTag.shorthand, tagName);
       expect(newTag.target, target);
@@ -243,7 +243,7 @@ void main() {
         message: message,
       );
 
-      final newTag = repo.lookupTag(oid);
+      final newTag = Tag.lookup(repo: repo, oid: oid);
       final tagger = newTag.tagger;
       final newTagTarget = newTag.target as Tag;
 
@@ -268,7 +268,7 @@ void main() {
         targetType: GitObject.tag,
       );
 
-      final newTag = repo.lookupReference('refs/tags/$tagName');
+      final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
 
       expect(newTag.shorthand, tagName);
       expect(newTag.target, tag.oid);
@@ -302,7 +302,7 @@ void main() {
         force: true,
       );
 
-      final newTag = repo.lookupTag(oid);
+      final newTag = Tag.lookup(repo: repo, oid: oid);
       final tagger = newTag.tagger;
       final newTagTarget = newTag.target as Commit;
 
@@ -337,7 +337,7 @@ void main() {
         force: true,
       );
 
-      final newTag = repo.lookupReference('refs/tags/$tagName');
+      final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
 
       expect(newTag.shorthand, tagName);
       expect(newTag.target, target);
@@ -408,14 +408,17 @@ void main() {
     });
 
     test('deletes tag', () {
-      expect(repo.tags, ['v0.1', 'v0.2']);
+      expect(Tag.list(repo), ['v0.1', 'v0.2']);
 
-      repo.deleteTag('v0.2');
-      expect(repo.tags, ['v0.1']);
+      Tag.delete(repo: repo, name: 'v0.2');
+      expect(Tag.list(repo), ['v0.1']);
     });
 
     test('throws when trying to delete non existing tag', () {
-      expect(() => repo.deleteTag('not.there'), throwsA(isA<LibGit2Error>()));
+      expect(
+        () => Tag.delete(repo: repo, name: 'not.there'),
+        throwsA(isA<LibGit2Error>()),
+      );
     });
   });
 }

--- a/test/tree_test.dart
+++ b/test/tree_test.dart
@@ -15,9 +15,7 @@ void main() {
   setUp(() {
     tmpDir = setupRepo(Directory(p.join('test', 'assets', 'test_repo')));
     repo = Repository.open(tmpDir.path);
-    tree = repo.lookupTree(
-      repo['a8ae3dd59e6e1802c6f78e05e301bfd57c9f334f'],
-    );
+    tree = Tree.lookup(repo: repo, oid: repo['a8ae3dd']);
   });
 
   tearDown(() {
@@ -34,7 +32,7 @@ void main() {
 
     test('throws when looking up tree for invalid oid', () {
       expect(
-        () => repo.lookupTree(repo['0' * 40]),
+        () => Tree.lookup(repo: repo, oid: repo['0' * 40]),
         throwsA(isA<LibGit2Error>()),
       );
     });
@@ -79,7 +77,7 @@ void main() {
     });
 
     test('creates tree', () {
-      final fileOid = repo.createBlob('blob content');
+      final fileOid = Blob.create(repo: repo, content: 'blob content');
       final builder = TreeBuilder(repo: repo);
 
       builder.add(
@@ -87,7 +85,7 @@ void main() {
         oid: fileOid,
         filemode: GitFilemode.blob,
       );
-      final newTree = repo.lookupTree(builder.write());
+      final newTree = Tree.lookup(repo: repo, oid: builder.write());
 
       final entry = newTree['filename'];
       expect(newTree.length, 1);

--- a/test/treebuilder_test.dart
+++ b/test/treebuilder_test.dart
@@ -15,7 +15,7 @@ void main() {
   setUp(() {
     tmpDir = setupRepo(Directory(p.join('test', 'assets', 'test_repo')));
     repo = Repository.open(tmpDir.path);
-    tree = repo.lookupTree(repo['a8ae3dd59e6e1802c6f78e05e301bfd57c9f334f']);
+    tree = Tree.lookup(repo: repo, oid: repo['a8ae3dd']);
   });
 
   tearDown(() {

--- a/test/worktree_test.dart
+++ b/test/worktree_test.dart
@@ -31,9 +31,10 @@ void main() {
 
   group('Worktree', () {
     test('creates worktree at provided path', () {
-      expect(repo.worktrees, <String>[]);
+      expect(Worktree.list(repo), <String>[]);
 
-      final worktree = repo.createWorktree(
+      final worktree = Worktree.create(
+        repo: repo,
         name: worktreeName,
         path: worktreeDir.path,
       );
@@ -54,17 +55,22 @@ void main() {
     });
 
     test('creates worktree at provided path from provided reference', () {
-      final head = repo.revParseSingle('HEAD');
-      final worktreeBranch = repo.createBranch(name: 'v1', target: head);
-      final ref = repo.lookupReference('refs/heads/v1');
+      final head = RevParse.single(repo: repo, spec: 'HEAD');
+      final worktreeBranch = Branch.create(
+        repo: repo,
+        name: 'v1',
+        target: head,
+      );
+      final ref = Reference.lookup(repo: repo, name: 'refs/heads/v1');
       expect(repo.worktrees, <String>[]);
 
-      final worktree = repo.createWorktree(
+      final worktree = Worktree.create(
+        repo: repo,
         name: worktreeName,
         path: worktreeDir.path,
         ref: ref,
       );
-      final branches = repo.branches;
+      final branches = Branch.list(repo: repo);
 
       expect(repo.worktrees, [worktreeName]);
       expect(branches.any((branch) => branch.name == 'v1'), true);
@@ -89,14 +95,16 @@ void main() {
 
     test('throws when trying to create worktree with invalid name or path', () {
       expect(
-        () => repo.createWorktree(
+        () => Worktree.create(
+          repo: repo,
           name: '',
           path: worktreeDir.path,
         ),
         throwsA(isA<LibGit2Error>()),
       );
       expect(
-        () => repo.createWorktree(
+        () => Worktree.create(
+          repo: repo,
           name: 'name',
           path: '',
         ),
@@ -105,11 +113,12 @@ void main() {
     });
 
     test('lookups worktree', () {
-      final worktree = repo.createWorktree(
+      final worktree = Worktree.create(
+        repo: repo,
         name: worktreeName,
         path: worktreeDir.path,
       );
-      final lookedupWorktree = repo.lookupWorktree(worktreeName);
+      final lookedupWorktree = Worktree.lookup(repo: repo, name: worktreeName);
 
       expect(lookedupWorktree.name, worktreeName);
       expect(lookedupWorktree.path, contains('worktree'));
@@ -127,7 +136,8 @@ void main() {
     });
 
     test('locks and unlocks worktree', () {
-      final worktree = repo.createWorktree(
+      final worktree = Worktree.create(
+        repo: repo,
         name: worktreeName,
         path: worktreeDir.path,
       );
@@ -145,7 +155,8 @@ void main() {
     test('prunes worktree', () {
       expect(repo.worktrees, <String>[]);
 
-      final worktree = repo.createWorktree(
+      final worktree = Worktree.create(
+        repo: repo,
         name: worktreeName,
         path: worktreeDir.path,
       );


### PR DESCRIPTION
BREAKING CHANGE: move API methods related to diffing into Diff class