### PR TITLE
refactor(repository)!: remove excessive aliases

### DIFF
--- a/example/reference_example.dart
+++ b/example/reference_example.dart
@@ -14,7 +14,7 @@ void main() {
   print('Repository references: ${repo.references}');
 
   // Get reference by name.
-  final ref = repo.lookupReference('refs/heads/master');
+  final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
 
   print('Reference SHA hex: ${ref.target.sha}');
   print('Is reference a local branch: ${ref.isBranch}');
@@ -22,16 +22,17 @@ void main() {
   print('Reference shorthand name: ${ref.shorthand}');
 
   // Create new reference (direct or symbolic).
-  final newRef = repo.createReference(
+  final newRef = Reference.create(
+    repo: repo,
     name: 'refs/tags/v1',
     target: 'refs/heads/master',
   );
 
   // Rename reference.
-  repo.renameReference(oldName: 'v1', newName: 'refs/tags/v1.1');
+  Reference.rename(repo: repo, oldName: 'v1', newName: 'refs/tags/v1.1');
 
   // Delete reference.
-  repo.deleteReference('v1.1');
+  Reference.delete(repo: repo, name: 'v1.1');
 
   // free() should be called on object to free memory when done.
   ref.free();

--- a/test/annotated_test.dart
+++ b/test/annotated_test.dart
@@ -41,7 +41,7 @@ void main() {
     });
 
     test('creates annotated commit from provided reference', () {
-      final reference = repo.lookupReference('refs/heads/master');
+      final reference = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final annotated = AnnotatedCommit.fromReference(
         repo: repo,
         reference: reference,
@@ -57,7 +57,7 @@ void main() {
     test(
         'throws when trying to create annotated commit from provided '
         'reference and error occurs', () {
-      final reference = repo.lookupReference('refs/heads/master');
+      final reference = Reference.lookup(repo: repo, name: 'refs/heads/master');
 
       expect(
         () => AnnotatedCommit.fromReference(

--- a/test/checkout_test.dart
+++ b/test/checkout_test.dart
@@ -71,9 +71,7 @@ void main() {
     });
 
     test('checkouts reference', () {
-      final masterHead = repo.lookupCommit(
-        repo['821ed6e80627b8769d170a293862f9fc60825226'],
-      );
+      final masterHead = Commit.lookup(repo: repo, oid: repo['821ed6e']);
       final masterTree = masterHead.tree;
       expect(
         masterTree.entries.any((e) => e.name == 'another_feature_file'),
@@ -81,9 +79,7 @@ void main() {
       );
 
       repo.checkout(target: 'refs/heads/feature');
-      final featureHead = repo.lookupCommit(
-        repo['5aecfa0fb97eadaac050ccb99f03c3fb65460ad4'],
-      );
+      final featureHead = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
       final featureTree = featureHead.tree;
       final repoHead = repo.head;
       expect(repoHead.target, featureHead.oid);
@@ -116,9 +112,7 @@ void main() {
       final index = repo.index;
       expect(index.find('another_feature_file'), equals(false));
 
-      final featureHead = repo.lookupCommit(
-        repo['5aecfa0fb97eadaac050ccb99f03c3fb65460ad4'],
-      );
+      final featureHead = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
       repo.checkout(target: featureHead.oid);
 
       final repoHead = repo.head;
@@ -132,9 +126,7 @@ void main() {
     });
 
     test('checkouts commit with provided path', () {
-      final featureHead = repo.lookupCommit(
-        repo['5aecfa0fb97eadaac050ccb99f03c3fb65460ad4'],
-      );
+      final featureHead = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
       repo.checkout(target: featureHead.oid, paths: ['another_feature_file']);
 
       final repoHead = repo.head;
@@ -167,7 +159,10 @@ void main() {
     });
 
     test('checkouts file with provided path', () {
-      final featureTip = repo.lookupReference('refs/heads/feature').target;
+      final featureTip = Reference.lookup(
+        repo: repo,
+        name: 'refs/heads/feature',
+      ).target;
 
       expect(repo.status, isEmpty);
       repo.checkout(

--- a/test/describe_test.dart
+++ b/test/describe_test.dart
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('describes commit', () {
-      repo.deleteTag('v0.2');
+      Tag.delete(repo: repo, name: 'v0.2');
 
       expect(
         repo.describe(describeStrategy: GitDescribeStrategy.tags),
@@ -41,13 +41,13 @@ void main() {
     });
 
     test('throws when trying to describe and no reference found', () {
-      final commit = repo.lookupCommit(repo['f17d0d48']);
+      final commit = Commit.lookup(repo: repo, oid: repo['f17d0d4']);
       expect(() => repo.describe(commit: commit), throwsA(isA<LibGit2Error>()));
       commit.free();
     });
 
     test('returns oid when fallback argument is provided', () {
-      final commit = repo.lookupCommit(repo['f17d0d48']);
+      final commit = Commit.lookup(repo: repo, oid: repo['f17d0d4']);
       expect(
         repo.describe(commit: commit, showCommitOidAsFallback: true),
         'f17d0d4',
@@ -56,7 +56,7 @@ void main() {
     });
 
     test('describes with provided strategy', () {
-      final commit = repo.lookupCommit(repo['5aecfa0']);
+      final commit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
       expect(
         repo.describe(
           commit: commit,
@@ -73,10 +73,11 @@ void main() {
         email: 'author@email.com',
         time: 1234,
       );
-      final commit = repo.lookupCommit(repo['fc38877']);
-      repo.createAnnotatedTag(
+      final commit = Commit.lookup(repo: repo, oid: repo['fc38877']);
+      Tag.createAnnotated(
+        repo: repo,
         tagName: 'test/tag1',
-        target: repo['f17d0d48'],
+        target: repo['f17d0d4'],
         targetType: GitObject.commit,
         tagger: signature,
         message: 'message',
@@ -92,8 +93,8 @@ void main() {
     });
 
     test('describes and follows first parent only', () {
-      final commit = repo.lookupCommit(repo['821ed6e']);
-      repo.deleteTag('v0.2');
+      final commit = Commit.lookup(repo: repo, oid: repo['821ed6e']);
+      Tag.delete(repo: repo, name: 'v0.2');
 
       expect(
         repo.describe(
@@ -108,8 +109,8 @@ void main() {
     });
 
     test('describes with provided abbreviated size', () {
-      final commit = repo.lookupCommit(repo['821ed6e']);
-      repo.deleteTag('v0.2');
+      final commit = Commit.lookup(repo: repo, oid: repo['821ed6e']);
+      Tag.delete(repo: repo, name: 'v0.2');
 
       expect(
         repo.describe(

--- a/test/diff_test.dart
+++ b/test/diff_test.dart
@@ -177,7 +177,7 @@ index e69de29..c217c63 100644
 
     test('returns diff between tree and workdir with index', () {
       final head = repo.head;
-      final commit = repo.lookupCommit(head.target);
+      final commit = Commit.lookup(repo: repo, oid: head.target);
       final tree = commit.tree;
 
       final diff = Diff.treeToWorkdirWithIndex(repo: repo, tree: tree);

--- a/test/index_test.dart
+++ b/test/index_test.dart
@@ -293,9 +293,7 @@ void main() {
     });
 
     test('reads tree with provided SHA hex', () {
-      final tree = repo.lookupTree(
-        repo['df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078'],
-      );
+      final tree = Tree.lookup(repo: repo, oid: repo['df2b8fc']);
       expect(index.length, 4);
       index.readTree(tree);
 
@@ -322,7 +320,7 @@ void main() {
       final tmpDir = setupRepo(Directory(mergeRepoPath));
       final repo = Repository.open(tmpDir.path);
 
-      final conflictBranch = repo.lookupBranch(name: 'conflict-branch');
+      final conflictBranch = Branch.lookup(repo: repo, name: 'conflict-branch');
       final index = repo.index;
       final commit = AnnotatedCommit.lookup(
         repo: repo,
@@ -357,7 +355,8 @@ void main() {
       final repoDir = setupRepo(Directory(mergeRepoPath));
       final conflictRepo = Repository.open(repoDir.path);
 
-      final conflictBranch = conflictRepo.lookupBranch(
+      final conflictBranch = Branch.lookup(
+        repo: conflictRepo,
         name: 'ancestor-conflict',
       );
       final commit = AnnotatedCommit.lookup(
@@ -387,7 +386,10 @@ void main() {
       final repoDir = setupRepo(Directory(mergeRepoPath));
       final conflictRepo = Repository.open(repoDir.path);
 
-      final conflictBranch = conflictRepo.lookupBranch(name: 'conflict-branch');
+      final conflictBranch = Branch.lookup(
+        repo: conflictRepo,
+        name: 'conflict-branch',
+      );
       final commit = AnnotatedCommit.lookup(
         repo: conflictRepo,
         oid: conflictBranch.target,
@@ -413,7 +415,8 @@ void main() {
       final repoDir = setupRepo(Directory(mergeRepoPath));
       final conflictRepo = Repository.open(repoDir.path);
 
-      final conflictBranch = conflictRepo.lookupBranch(
+      final conflictBranch = Branch.lookup(
+        repo: conflictRepo,
         name: 'ancestor-conflict',
       );
       final commit = AnnotatedCommit.lookup(
@@ -443,7 +446,10 @@ void main() {
       final repoDir = setupRepo(Directory(mergeRepoPath));
       final conflictRepo = Repository.open(repoDir.path);
 
-      final conflictBranch = conflictRepo.lookupBranch(name: 'their-conflict');
+      final conflictBranch = Branch.lookup(
+        repo: conflictRepo,
+        name: 'their-conflict',
+      );
       final commit = AnnotatedCommit.lookup(
         repo: conflictRepo,
         oid: conflictBranch.target,
@@ -471,7 +477,10 @@ void main() {
       final repoDir = setupRepo(Directory(mergeRepoPath));
       final conflictRepo = Repository.open(repoDir.path);
 
-      final conflictBranch = conflictRepo.lookupBranch(name: 'conflict-branch');
+      final conflictBranch = Branch.lookup(
+        repo: conflictRepo,
+        name: 'conflict-branch',
+      );
       final commit = AnnotatedCommit.lookup(
         repo: conflictRepo,
         oid: conflictBranch.target,
@@ -509,7 +518,10 @@ void main() {
       final repoDir = setupRepo(Directory(mergeRepoPath));
       final conflictRepo = Repository.open(repoDir.path);
 
-      final conflictBranch = conflictRepo.lookupBranch(name: 'conflict-branch');
+      final conflictBranch = Branch.lookup(
+        repo: conflictRepo,
+        name: 'conflict-branch',
+      );
       final commit = AnnotatedCommit.lookup(
         repo: conflictRepo,
         oid: conflictBranch.target,

--- a/test/merge_test.dart
+++ b/test/merge_test.dart
@@ -44,8 +44,9 @@ void main() {
       });
 
       test('is fast forward', () {
-        final ffCommit = repo.lookupCommit(repo['f17d0d4']);
-        final ffBranch = repo.createBranch(
+        final ffCommit = Commit.lookup(repo: repo, oid: repo['f17d0d4']);
+        final ffBranch = Branch.create(
+          repo: repo,
           name: 'ff-branch',
           target: ffCommit,
         );
@@ -72,7 +73,7 @@ void main() {
     });
 
     test('writes conflicts to index', () {
-      final conflictBranch = repo.lookupBranch(name: 'conflict-branch');
+      final conflictBranch = Branch.lookup(repo: repo, name: 'conflict-branch');
       final commit = AnnotatedCommit.lookup(
         repo: repo,
         oid: conflictBranch.target,
@@ -123,7 +124,10 @@ master conflict edit
 conflict branch edit
 >>>>>>> conflict_file
 """;
-        final conflictBranch = repo.lookupBranch(name: 'conflict-branch');
+        final conflictBranch = Branch.lookup(
+          repo: repo,
+          name: 'conflict-branch',
+        );
         final commit = AnnotatedCommit.lookup(
           repo: repo,
           oid: conflictBranch.target,
@@ -154,7 +158,10 @@ Feature edit on feature branch
 Another feature edit
 >>>>>>> feature_file
 """;
-        final conflictBranch = repo.lookupBranch(name: 'ancestor-conflict');
+        final conflictBranch = Branch.lookup(
+          repo: repo,
+          name: 'ancestor-conflict',
+        );
         final commit = AnnotatedCommit.lookup(
           repo: repo,
           oid: conflictBranch.target,
@@ -186,7 +193,10 @@ master conflict edit
 conflict branch edit
 >>>>>>> conflict_file
 """;
-        final conflictBranch = repo.lookupBranch(name: 'conflict-branch');
+        final conflictBranch = Branch.lookup(
+          repo: repo,
+          name: 'conflict-branch',
+        );
         final commit = AnnotatedCommit.lookup(
           repo: repo,
           oid: conflictBranch.target,
@@ -214,7 +224,10 @@ conflict branch edit
       });
 
       test('merges with provided merge favor', () {
-        final conflictBranch = repo.lookupBranch(name: 'conflict-branch');
+        final conflictBranch = Branch.lookup(
+          repo: repo,
+          name: 'conflict-branch',
+        );
         final commit = AnnotatedCommit.lookup(
           repo: repo,
           oid: conflictBranch.target,
@@ -303,12 +316,12 @@ theirs content
 
     group('merge commits', () {
       test('merges with default values', () {
-        final theirCommit = repo.lookupCommit(repo['5aecfa0']);
+        final theirCommit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
         final theirCommitAnnotated = AnnotatedCommit.lookup(
           repo: repo,
           oid: theirCommit.oid,
         );
-        final ourCommit = repo.lookupCommit(repo['1490545']);
+        final ourCommit = Commit.lookup(repo: repo, oid: repo['1490545']);
 
         final mergeIndex = repo.mergeCommits(
           ourCommit: ourCommit,
@@ -332,8 +345,8 @@ theirs content
       });
 
       test('merges with provided favor', () {
-        final theirCommit = repo.lookupCommit(repo['5aecfa0']);
-        final ourCommit = repo.lookupCommit(repo['1490545']);
+        final theirCommit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
+        final ourCommit = Commit.lookup(repo: repo, oid: repo['1490545']);
 
         final mergeIndex = repo.mergeCommits(
           ourCommit: ourCommit,
@@ -348,8 +361,8 @@ theirs content
       });
 
       test('merges with provided merge and file flags', () {
-        final theirCommit = repo.lookupCommit(repo['5aecfa0']);
-        final ourCommit = repo.lookupCommit(repo['1490545']);
+        final theirCommit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
+        final ourCommit = Commit.lookup(repo: repo, oid: repo['1490545']);
 
         final mergeIndex = repo.mergeCommits(
           ourCommit: ourCommit,
@@ -454,14 +467,15 @@ theirs content
 
     group('merge trees', () {
       test('merges with default values', () {
-        final theirCommit = repo.lookupCommit(repo['5aecfa0']);
+        final theirCommit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
         final theirCommitAnnotated = AnnotatedCommit.lookup(
           repo: repo,
           oid: theirCommit.oid,
         );
-        final ourCommit = repo.lookupCommit(repo['1490545']);
-        final baseCommit = repo.lookupCommit(
-          repo.mergeBase([ourCommit.oid, theirCommit.oid]),
+        final ourCommit = Commit.lookup(repo: repo, oid: repo['1490545']);
+        final baseCommit = Commit.lookup(
+          repo: repo,
+          oid: repo.mergeBase([ourCommit.oid, theirCommit.oid]),
         );
         final theirTree = theirCommit.tree;
         final ourTree = ourCommit.tree;
@@ -495,10 +509,11 @@ theirs content
       });
 
       test('merges with provided favor', () {
-        final theirCommit = repo.lookupCommit(repo['5aecfa0']);
-        final ourCommit = repo.lookupCommit(repo['1490545']);
-        final baseCommit = repo.lookupCommit(
-          repo.mergeBase([ourCommit.oid, theirCommit.oid]),
+        final theirCommit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
+        final ourCommit = Commit.lookup(repo: repo, oid: repo['1490545']);
+        final baseCommit = Commit.lookup(
+          repo: repo,
+          oid: repo.mergeBase([ourCommit.oid, theirCommit.oid]),
         );
         final theirTree = theirCommit.tree;
         final ourTree = ourCommit.tree;
@@ -534,7 +549,7 @@ theirs content
     });
 
     test('cherry-picks commit', () {
-      final cherry = repo.lookupCommit(repo['5aecfa0']);
+      final cherry = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
       repo.cherryPick(cherry);
       expect(repo.state, GitRepositoryState.cherrypick);
       expect(repo.message, 'add another feature file\n');

--- a/test/remote_prune_test.dart
+++ b/test/remote_prune_test.dart
@@ -23,8 +23,8 @@ void main() {
       url: tmpDir.path,
       localPath: cloneDir.path,
     );
-    originRepo.deleteBranch('feature');
-    remote = clonedRepo.lookupRemote('origin');
+    Branch.delete(repo: originRepo, name: 'feature');
+    remote = Remote.lookup(repo: clonedRepo, name: 'origin');
   });
 
   tearDown(() {

--- a/test/repository_clone_test.dart
+++ b/test/repository_clone_test.dart
@@ -72,7 +72,7 @@ void main() {
 
     test('clones repository with provided remote callback', () {
       Remote remote(Repository repo, String name, String url) =>
-          repo.createRemote(name: 'test', url: tmpDir.path);
+          Remote.create(repo: repo, name: 'test', url: tmpDir.path);
 
       final clonedRepo = Repository.clone(
         url: tmpDir.path,
@@ -90,7 +90,7 @@ void main() {
 
     test('throws when cloning repository with invalid remote callback', () {
       Remote remote(Repository repo, String name, String url) =>
-          repo.createRemote(name: '', url: '');
+          Remote.create(repo: repo, name: '', url: '');
 
       expect(
         () => Repository.clone(

--- a/test/repository_init_test.dart
+++ b/test/repository_init_test.dart
@@ -51,7 +51,7 @@ void main() {
         File(p.join(repo.path, 'description')).readAsStringSync(),
         'test repo',
       );
-      expect(repo.lookupRemote('origin').url, 'test.url');
+      expect(Remote.lookup(repo: repo, name: 'origin').url, 'test.url');
     });
   });
 }

--- a/test/repository_test.dart
+++ b/test/repository_test.dart
@@ -162,91 +162,6 @@ void main() {
       });
     });
 
-    group('createBlob', () {
-      const newBlobContent = 'New blob\n';
-
-      test('creates new blob', () {
-        final oid = repo.createBlob(newBlobContent);
-        final newBlob = repo.lookupBlob(oid);
-
-        expect(newBlob, isA<Blob>());
-
-        newBlob.free();
-      });
-
-      test('creates new blob from file at provided relative path', () {
-        final oid = repo.createBlobFromWorkdir('feature_file');
-        final newBlob = repo.lookupBlob(oid);
-
-        expect(newBlob, isA<Blob>());
-
-        newBlob.free();
-      });
-
-      test('creates new blob from file at provided path', () {
-        final outsideFile = File(
-          p.join(Directory.current.absolute.path, 'test', 'blob_test.dart'),
-        );
-        final oid = repo.createBlobFromDisk(outsideFile.path);
-        final newBlob = repo.lookupBlob(oid);
-
-        expect(newBlob, isA<Blob>());
-
-        newBlob.free();
-      });
-    });
-
-    test('creates annotated tag with provided sha', () {
-      final signature = Signature.create(
-        name: 'Author',
-        email: 'author@email.com',
-        time: 1234,
-      );
-      const tagName = 'tag';
-      final target = repo['f17d0d48eae3aa08cecf29128a35e310c97b3521'];
-      const message = 'init tag\n';
-
-      final oid = repo.createAnnotatedTag(
-        tagName: tagName,
-        target: target,
-        targetType: GitObject.commit,
-        tagger: signature,
-        message: message,
-      );
-
-      final newTag = repo.lookupTag(oid);
-      final tagger = newTag.tagger;
-      final newTagTarget = newTag.target as Commit;
-
-      expect(newTag.oid, oid);
-      expect(newTag.name, tagName);
-      expect(newTag.message, message);
-      expect(tagger, signature);
-      expect(newTagTarget.oid, target);
-
-      newTag.free();
-      newTagTarget.free();
-      signature.free();
-    });
-
-    test('creates lightweight tag with provided sha', () {
-      const tagName = 'tag';
-      final target = repo['f17d0d48eae3aa08cecf29128a35e310c97b3521'];
-
-      repo.createLightweightTag(
-        tagName: tagName,
-        target: target,
-        targetType: GitObject.commit,
-      );
-
-      final newTag = repo.lookupReference('refs/tags/$tagName');
-
-      expect(newTag.shorthand, tagName);
-      expect(newTag.target, target);
-
-      newTag.free();
-    });
-
     test('returns status of a repository', () {
       File(p.join(tmpDir.path, 'new_file.txt')).createSync();
       final index = repo.index;
@@ -273,7 +188,7 @@ void main() {
 
     test('cleans up state', () {
       expect(repo.state, GitRepositoryState.none);
-      final commit = repo.lookupCommit(repo['5aecfa0']);
+      final commit = Commit.lookup(repo: repo, oid: repo['5aecfa0']);
       repo.cherryPick(commit);
 
       expect(repo.state, GitRepositoryState.cherrypick);
@@ -364,8 +279,8 @@ void main() {
     });
 
     test('returns number of ahead behind commits', () {
-      final commit1 = repo.lookupCommit(repo['821ed6e8']);
-      final commit2 = repo.lookupCommit(repo['c68ff54a']);
+      final commit1 = Commit.lookup(repo: repo, oid: repo['821ed6e']);
+      final commit2 = Commit.lookup(repo: repo, oid: repo['c68ff54']);
 
       expect(
         repo.aheadBehind(local: commit1.oid, upstream: commit2.oid),

--- a/test/stash_test.dart
+++ b/test/stash_test.dart
@@ -56,7 +56,7 @@ void main() {
       expect(repo.status.isEmpty, true);
       expect(swpPath.existsSync(), false);
 
-      repo.applyStash();
+      Stash.apply(repo: repo);
       expect(swpPath.existsSync(), true);
     });
 
@@ -131,7 +131,7 @@ void main() {
       final stash = repo.stashes.first;
       Stash.drop(repo: repo, index: stash.index);
 
-      expect(() => repo.applyStash(), throwsA(isA<LibGit2Error>()));
+      expect(() => Stash.apply(repo: repo), throwsA(isA<LibGit2Error>()));
     });
 
     test('throws when trying to drop with wrong index', () {


### PR DESCRIPTION
BREAKING CHANGE: instead of removed aliases, API methods from relevant classes should be called (e.g. Commit.create, Reference.lookup, etc.)